### PR TITLE
Add entities to show channel on hours

### DIFF
--- a/release/lovelace/lovelace_views.yaml
+++ b/release/lovelace/lovelace_views.yaml
@@ -33,13 +33,21 @@ views:
       - type: logbook
         entities:
           - sensor.porssari_channel_1_state
+          - sensor.porssari_channel_1_on_hours
           - sensor.porssari_channel_2_state
+          - sensor.porssari_channel_2_on_hours
           - sensor.porssari_channel_3_state
+          - sensor.porssari_channel_3_on_hours
           - sensor.porssari_channel_4_state
+          - sensor.porssari_channel_4_on_hours
           - sensor.porssari_channel_5_state
+          - sensor.porssari_channel_5_on_hours
           - sensor.porssari_channel_6_state
+          - sensor.porssari_channel_6_on_hours
           - sensor.porssari_channel_7_state
+          - sensor.porssari_channel_7_on_hours
           - sensor.porssari_channel_8_state
+          - sensor.porssari_channel_8_on_hours
         title: Kanavaohjaushistoria
         hours_to_show: 24
       - type: entities

--- a/release/porssari_core.yaml
+++ b/release/porssari_core.yaml
@@ -193,6 +193,294 @@ template:
           {% else %}
             {{ -1 }}
           {% endif %}
+      - name: "Pörssäri Channel 1 on hours"
+        unique_id: porssari_ch1_on_hours
+        state: >
+          {% set ch = '1' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
+      - name: "Pörssäri Channel 2 on hours"
+        unique_id: porssari_ch2_on_hours
+        state: >
+          {% set ch = '2' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
+      - name: "Pörssäri Channel 3 on hours"
+        unique_id: porssari_ch3_on_hours
+        state: >
+          {% set ch = '3' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
+      - name: "Pörssäri Channel 4 on hours"
+        unique_id: porssari_ch4_on_hours
+        state: >
+          {% set ch = '4' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
+      - name: "Pörssäri Channel 5 on hours"
+        unique_id: porssari_ch5_on_hours
+        state: >
+          {% set ch = '5' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
+      - name: "Pörssäri Channel 6 on hours"
+        unique_id: porssari_ch6_on_hours
+        state: >
+          {% set ch = '6' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
+      - name: "Pörssäri Channel 7 on hours"
+        unique_id: porssari_ch7_on_hours
+        state: >
+          {% set ch = '7' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
+      - name: "Pörssäri Channel 8 on hours"
+        unique_id: porssari_ch8_on_hours
+        state: >
+          {% set ch = '8' %}
+          {% set controls = state_attr('sensor.porssari_json_data', 'controls') %}
+
+          {% if not controls %}
+            JSON-data ei saatavilla
+          {% else %}
+            {% set channel = controls | selectattr('id','equalto',ch) | first %}
+            {% if not channel %}
+              Id: {{ ch }} ei löydy
+            {% elif not channel.schedules %}
+              Ei ajastuksia
+            {% else %}
+
+              {% set sorted = channel.schedules | sort(attribute='timestamp') %}
+
+              {% for s in sorted[:4] %}
+                {% set t = s.timestamp | int %}
+                {% if (t % 900) >= 450 %}
+                  {% set r = ((t // 900) + 1) * 900 %}
+                {% else %}
+                  {% set r = (t // 900) * 900 %}
+                {% endif %}
+
+                {% if s.state == '1' %}
+                  {{ r | timestamp_custom('%H:%M') }}
+                {% elif s.state == '0' %}
+                  {{ '−' ~ (r | timestamp_custom('%H:%M,')) }}
+                {% endif %}
+                {% if not loop.last %} {% endif %}
+              {% endfor %}
+
+            {% endif %}
+          {% endif %}
 
   # Sensor to save request json data.
   - sensor:
@@ -220,6 +508,8 @@ template:
           {% else %}
             {{ false }}
           {% endif %}
+
+
 
 # Update logic for json-sensor.
 automation:


### PR DESCRIPTION
Lisäsin entiteetit, jotka näyttävät neljä seuraavaa muutosta kanavien tilaan. Ajat pyöristyvät lähimpään varttituntiin.

<img width="547" height="131" alt="kuva" src="https://github.com/user-attachments/assets/ec5ecbbd-ebe9-43dc-8448-b6cf0a72c768" />
